### PR TITLE
Add missing .am under vendors

### DIFF
--- a/vendors/Makefile.am
+++ b/vendors/Makefile.am
@@ -1,0 +1,1 @@
+SUBDIRS = dict


### PR DESCRIPTION
It is required for executing autogen.sh